### PR TITLE
[fix][broker] Refactor ByteBuf release method in module pulsar-broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -26,6 +26,7 @@ import com.github.zafarkhaja.semver.Version;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
@@ -3192,11 +3193,11 @@ public class PersistentTopicsBase extends AdminResource {
         ByteBuf data = PulsarByteBufAllocator.DEFAULT.heapBuffer(uncompressedPayload.readableBytes(),
                 uncompressedPayload.readableBytes());
         data.writeBytes(uncompressedPayload);
-        uncompressedPayload.release();
+        ReferenceCountUtil.safeRelease(uncompressedPayload);
 
         StreamingOutput stream = output -> {
             output.write(data.array(), data.arrayOffset(), data.readableBytes());
-            data.release();
+            ReferenceCountUtil.safeRelease(data);
         };
 
         return responseBuilder.entity(stream).build();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceUsageTopicTransportManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceUsageTopicTransportManager.java
@@ -23,6 +23,7 @@ import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowabl
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +106,7 @@ public class ResourceUsageTopicTransportManager implements ResourceUsageTranspor
                     if (null != ex) {
                         LOG.error("Resource usage publisher: error sending message ID {}", id, ex);
                     }
-                    buf.release();
+                    ReferenceCountUtil.safeRelease(buf);
                 });
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -24,6 +24,7 @@ import static org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaTy
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import com.carrotsearch.hppc.ObjectObjectHashMap;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -196,7 +197,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             ByteBuf duplicateBuffer = data.retainedDuplicate();
             Entry entry = create(0L, 0L, duplicateBuffer);
             // entry internally retains data so, duplicateBuffer should be release here
-            duplicateBuffer.release();
+            ReferenceCountUtil.safeRelease(duplicateBuffer);
             if (subscription.getDispatcher() != null) {
                 subscription.getDispatcher().sendMessages(Collections.singletonList(entry));
             } else {
@@ -211,7 +212,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 ByteBuf duplicateBuffer = data.retainedDuplicate();
                 Entry entry = create(0L, 0L, duplicateBuffer);
                 // entry internally retains data so, duplicateBuffer should be release here
-                duplicateBuffer.release();
+                ReferenceCountUtil.safeRelease(duplicateBuffer);
                 replicator.sendMessage(entry);
             });
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
@@ -159,7 +160,7 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                 CompletableFuture<SchemaInfo> schemaFuture = getSchemaInfo(msg);
                 if (!schemaFuture.isDone() || schemaFuture.isCompletedExceptionally()) {
                     entry.release();
-                    headersAndPayload.release();
+                    ReferenceCountUtil.safeRelease(headersAndPayload);
                     msg.recycle();
                     // Mark the replicator is fetching the schema for now and rewind the cursor
                     // and trigger the next read after complete the schema fetching.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.persistent;
 
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import io.prometheus.client.Gauge;
 import java.io.IOException;
 import java.time.Clock;
@@ -272,7 +273,7 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         try {
             topic.publishMessage(marker, this);
         } finally {
-            marker.release();
+            ReferenceCountUtil.safeRelease(marker);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -161,7 +162,7 @@ class InMemTransactionBuffer implements TransactionBuffer {
         public void close() {
             synchronized (entries) {
                 entries.forEach((sequenceId, buffer) -> {
-                    buffer.release();
+                    ReferenceCountUtil.safeRelease(buffer);
                 });
                 entries.clear();
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferReader.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -91,7 +92,7 @@ public class InMemTransactionBufferReader implements TransactionBufferReader {
     public synchronized void close() {
         while (entries.hasNext()) {
             Entry<Long, ByteBuf> entry = entries.next();
-            entry.getValue().release();
+            ReferenceCountUtil.safeRelease(entry.getValue());
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import io.netty.util.TimerTask;
@@ -320,7 +321,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     }
                 }, null);
             } finally {
-                commitMarker.release();
+                ReferenceCountUtil.safeRelease(commitMarker);
             }
         }).exceptionally(exception -> {
             log.error("Transaction {} commit on topic {}.", txnID.toString(), topic.getName(), exception.getCause());
@@ -367,7 +368,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     }
                 }, null);
             } finally {
-                abortMarker.release();
+                ReferenceCountUtil.safeRelease(abortMarker);
             }
         }).exceptionally(exception -> {
             log.error("Transaction {} abort on topic {}.", txnID.toString(), topic.getName(), exception.getCause());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.transaction.buffer.TransactionEntry;
@@ -92,7 +93,7 @@ public class TransactionEntryImpl implements TransactionEntry {
     @Override
     public void close() {
         if (null != entry) {
-            entry.getDataBuffer().release();
+            ReferenceCountUtil.safeRelease(entry.getDataBuffer());
             entry.release();
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
@@ -22,6 +22,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
+
+import io.netty.util.ReferenceCountUtil;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
@@ -68,13 +70,13 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
                 public ByteBuf process(Object contextObj, ByteBuf inputPayload) {
                     byte[] newMessage = (new String("Modified Test Message")).getBytes();
                     ByteBuf processedPayload =  Unpooled.wrappedBuffer(newMessage, 0, newMessage.length);
-                    inputPayload.release();
+                    ReferenceCountUtil.safeRelease(inputPayload);
                     return processedPayload.retainedDuplicate();
                 }
 
                 @Override
                 public void release(ByteBuf processedPayload) {
-                    processedPayload.release();
+                    ReferenceCountUtil.safeRelease(processedPayload);
                 }
             };
         }
@@ -89,13 +91,13 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
                     Assert.assertTrue(storedMessage.equals("Modified Test Message"));
 
                     byte[] newMessage = (new String("Test Message")).getBytes();
-                    inputPayload.release();
+                    ReferenceCountUtil.safeRelease(inputPayload);
                     return Unpooled.wrappedBuffer(newMessage, 0, newMessage.length).retainedDuplicate();
                 }
 
                 @Override
                 public void release(ByteBuf processedPayload) {
-                    processedPayload.release();
+                    ReferenceCountUtil.safeRelease(processedPayload);
                 }
             };
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -48,6 +48,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Supplier;
+
+import io.netty.util.ReferenceCountUtil;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
@@ -126,7 +128,7 @@ public class PersistentDispatcherFailoverConsumerTest {
                     consumerChanges.put(cmd.getActiveConsumerChange());
                 }
             } finally {
-                cmdBuf.release();
+                ReferenceCountUtil.safeRelease(cmdBuf);
             }
 
             return null;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -59,6 +59,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+
+import io.netty.util.ReferenceCountUtil;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
@@ -741,7 +743,7 @@ public class ServerCnxTest {
 
         clientCommand = ByteBufPair.coalesce(Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data));
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
-        clientCommand.release();
+        ReferenceCountUtil.safeRelease(clientCommand);
 
         assertTrue(getResponse() instanceof CommandSendReceipt);
         channel.finish();
@@ -762,7 +764,7 @@ public class ServerCnxTest {
         ByteBuf clientCommand = ByteBufPair.coalesce(Commands.newSend(1, 0, 1,
                 ChecksumType.None, messageMetadata, data));
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
-        clientCommand.release();
+        ReferenceCountUtil.safeRelease(clientCommand);
 
         // Then expect channel to close
         Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !channel.isActive());
@@ -1636,7 +1638,7 @@ public class ServerCnxTest {
 
         clientCommand = ByteBufPair.coalesce(Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data));
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
-        clientCommand.release();
+        ReferenceCountUtil.safeRelease(clientCommand);
         assertTrue(getResponse() instanceof CommandSendReceipt);
         channel.finish();
     }
@@ -1679,7 +1681,7 @@ public class ServerCnxTest {
 
         clientCommand = ByteBufPair.coalesce(Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data));
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
-        clientCommand.release();
+        ReferenceCountUtil.safeRelease(clientCommand);
         assertTrue(getResponse() instanceof CommandSendError);
         channel.finish();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImplTest.java
@@ -29,6 +29,8 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import io.netty.util.ReferenceCountUtil;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.EncryptionKeyInfo;
 import org.apache.pulsar.client.api.MessageCrypto;
@@ -136,11 +138,11 @@ public class RawBatchMessageContainerImplTest {
 
         Assert.assertEquals(payload1.toString(Charset.defaultCharset()), "hi-1");
         Assert.assertEquals(payload2.toString(Charset.defaultCharset()), "hi-2");
-        payload1.release();
-        payload2.release();
+        ReferenceCountUtil.safeRelease(payload1);
+        ReferenceCountUtil.safeRelease(payload2);
         singleMessageMetadataAndPayload.release();
-        metadataAndPayload.release();
-        buf.release();
+        ReferenceCountUtil.safeRelease(metadataAndPayload);
+        ReferenceCountUtil.safeRelease(buf);
     }
 
     @Test
@@ -187,12 +189,12 @@ public class RawBatchMessageContainerImplTest {
 
         Assert.assertEquals(payload1.toString(Charset.defaultCharset()), "hi-1");
         Assert.assertEquals(payload2.toString(Charset.defaultCharset()), "hi-2");
-        payload1.release();
-        payload2.release();
+        ReferenceCountUtil.safeRelease(payload1);
+        ReferenceCountUtil.safeRelease(payload2);
         singleMessageMetadataAndPayload.release();
-        metadataAndPayload.release();
-        uncompressed.release();
-        buf.release();
+        ReferenceCountUtil.safeRelease(metadataAndPayload);
+        ReferenceCountUtil.safeRelease(uncompressed);
+        ReferenceCountUtil.safeRelease(buf);
     }
 
     @Test
@@ -222,8 +224,8 @@ public class RawBatchMessageContainerImplTest {
 
         Assert.assertEquals(singleMessageMetadataAndPayload.getPayload().toString(Charset.defaultCharset()), "hi-1");
         singleMessageMetadataAndPayload.release();
-        metadataAndPayload.release();
-        buf.release();
+        ReferenceCountUtil.safeRelease(metadataAndPayload);
+        ReferenceCountUtil.safeRelease(buf);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/CustomBatchPayloadProcessor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/CustomBatchPayloadProcessor.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.client.processor;
 
 import io.netty.buffer.ByteBuf;
 import java.util.function.Consumer;
+
+import io.netty.util.ReferenceCountUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.MessagePayloadContext;
 import org.apache.pulsar.client.api.Message;
@@ -55,7 +57,7 @@ public class CustomBatchPayloadProcessor implements MessagePayloadProcessor {
                 }
             }
         } finally {
-            buf.release();
+            ReferenceCountUtil.safeRelease(buf);
         }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/CustomBatchProducer.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/CustomBatchProducer.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.client.processor;
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.List;
+
+import io.netty.util.ReferenceCountUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -46,7 +48,7 @@ public class CustomBatchProducer {
         final ByteBuf buf = CustomBatchFormat.serialize(messages);
         final ByteBuf headerAndPayload = Commands.serializeMetadataAndPayload(Commands.ChecksumType.None,
                 createCustomMetadata(), buf);
-        buf.release();
+        ReferenceCountUtil.safeRelease(buf);
         persistentTopic.publishMessage(headerAndPayload, (e, ledgerId, entryId) -> {
             if (e == null) {
                 log.info("Send successfully to {} ({}, {})", persistentTopic.getName(), ledgerId, entryId);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/MessagePayloadProcessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/MessagePayloadProcessorTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -182,7 +183,7 @@ public class MessagePayloadProcessorTest extends ProducerConsumerBase {
             Assert.assertEquals(parsedTokens.size(), input.size());
 
             Assert.assertEquals(buf.refCnt(), 1);
-            buf.release();
+            ReferenceCountUtil.safeRelease(buf);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -46,6 +46,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import io.netty.util.ReferenceCountUtil;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -1771,7 +1773,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
                     //
                 }
             }, null);
-            marker.release();
+            ReferenceCountUtil.safeRelease(marker);
         }
         producer.send("msg-2".getBytes(StandardCharsets.UTF_8));
         admin.topics().triggerCompaction(dest.toString());


### PR DESCRIPTION
### Motivation

It may throw an exception when release a `ByteBuf` object. so the exception in `ByteBuf.release` should be checked.

### Modifications
Use `ReferenceCountUtil.safeRelease()` instead of `ByteBuf.release()` in all Pulsar's classes.

### Verifying this change
- [ ] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation
Check the box below or label this PR directly.

Need to update docs?

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
PR in forked repository: https://github.com/StevenLuMT/pulsar/pull/4